### PR TITLE
feat: RocksDB Integration (Issue #11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/*.rs.bk
 node*.log
 discussion.json
+
+db/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,22 +273,50 @@ checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bincode"
-version = "2.0.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "bincode_derive",
  "serde",
- "unty",
 ]
 
 [[package]]
-name = "bincode_derive"
-version = "2.0.1"
+name = "bindgen"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
- "virtue",
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -361,13 +389,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -415,6 +464,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1372,6 +1432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1471,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,10 +1497,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libp2p"
@@ -1744,6 +1839,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen 0.65.1",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,6 +1906,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "match-lookup"
@@ -2040,6 +2172,7 @@ dependencies = [
  "libp2p",
  "log",
  "rand 0.8.5",
+ "rocksdb",
  "serde",
  "serde_json",
  "sha2",
@@ -2114,6 +2247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2309,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
@@ -2248,6 +2393,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,7 +2468,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.1",
  "thiserror 2.0.17",
@@ -2333,7 +2488,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2503,6 +2658,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2684,12 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3072,12 +3243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,16 +3278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "want"
@@ -3687,4 +3852,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 async-trait = "0.1.89"
-bincode = "2.0.1"
+bincode = "1.3.3"
 blst = "0.3.13"
 env_logger = "0.11.8"
 futures = "0.3.31"
@@ -13,6 +13,7 @@ hex = "0.4.3"
 libp2p = { version = "0.56.0", features = ["gossipsub", "mdns", "noise", "tcp", "yamux", "tokio", "macros"] }
 log = "0.4.29"
 rand = "0.8.5"
+rocksdb = "0.21.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10.9"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This project is being developed in 4 phases:
 
 - [ ] **Phase 3: Cryptography and Storage**
     - [x] Replace mock crypto with `blst` (BLS12-381).
-    - [ ] `RocksDB` integration for persistence.
+    - [x] `RocksDB` integration for persistence.
     - [ ] Sync protocol.
 
 - [ ] **Phase 4: Optimization and Tooling**

--- a/scripts/test_cluster.sh
+++ b/scripts/test_cluster.sh
@@ -3,6 +3,10 @@
 trap "kill 0" EXIT
 
 # Build
+echo "Cleaning DB and Logs..."
+rm -rf ./db
+rm -f node*.log
+
 echo "Building..."
 cargo build --quiet
 

--- a/scripts/test_failure.sh
+++ b/scripts/test_failure.sh
@@ -9,7 +9,9 @@ cleanup() {
 trap cleanup EXIT
 
 # Clean old logs
+# Clean old logs and DB
 rm -f node*.log
+rm -rf ./db
 
 echo "Building..."
 cargo build --quiet

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod consensus;
 pub mod crypto;
 pub mod network;
+pub mod storage;
 pub mod types;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,165 @@
+use crate::crypto::Hash;
+use crate::types::{Block, QuorumCertificate, View};
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum StorageError {
+    #[error("RocksDB error: {0}")]
+    RocksDB(#[from] rocksdb::Error),
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] bincode::Error),
+    #[error("Not found")]
+    NotFound,
+}
+
+/// Persistent State that needs to be saved atomically (or somewhat atomically)
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct ConsensusState {
+    pub view: View,
+    pub finalized_height: View,
+    pub preferred_block: Hash,
+    pub preferred_view: View,
+}
+
+pub trait Storage: Send + Sync {
+    fn save_block(&self, block: &Block) -> Result<(), StorageError>;
+    fn get_block(&self, hash: &Hash) -> Result<Option<Block>, StorageError>;
+
+    fn save_qc(&self, qc: &QuorumCertificate) -> Result<(), StorageError>;
+    fn get_qc(&self, view: View) -> Result<Option<QuorumCertificate>, StorageError>;
+
+    fn save_consensus_state(&self, state: &ConsensusState) -> Result<(), StorageError>;
+    fn get_consensus_state(&self) -> Result<Option<ConsensusState>, StorageError>;
+}
+
+// -----------------------------------------------------------------------------
+// In-Memory Storage (for Copy/Clone tests where RocksDB is too heavy or needs paths)
+// -----------------------------------------------------------------------------
+#[derive(Clone, Default)]
+pub struct MemStorage {
+    blocks: Arc<Mutex<HashMap<Hash, Block>>>,
+    qcs: Arc<Mutex<HashMap<View, QuorumCertificate>>>,
+    state: Arc<Mutex<Option<ConsensusState>>>,
+}
+
+impl MemStorage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Storage for MemStorage {
+    fn save_block(&self, block: &Block) -> Result<(), StorageError> {
+        let hash = crate::crypto::hash_data(block);
+        self.blocks.lock().unwrap().insert(hash, block.clone());
+        Ok(())
+    }
+
+    fn get_block(&self, hash: &Hash) -> Result<Option<Block>, StorageError> {
+        Ok(self.blocks.lock().unwrap().get(hash).cloned())
+    }
+
+    fn save_qc(&self, qc: &QuorumCertificate) -> Result<(), StorageError> {
+        self.qcs.lock().unwrap().insert(qc.view, qc.clone());
+        Ok(())
+    }
+
+    fn get_qc(&self, view: View) -> Result<Option<QuorumCertificate>, StorageError> {
+        Ok(self.qcs.lock().unwrap().get(&view).cloned())
+    }
+
+    fn save_consensus_state(&self, state: &ConsensusState) -> Result<(), StorageError> {
+        *self.state.lock().unwrap() = Some(state.clone());
+        Ok(())
+    }
+
+    fn get_consensus_state(&self) -> Result<Option<ConsensusState>, StorageError> {
+        Ok(self.state.lock().unwrap().clone())
+    }
+}
+
+// -----------------------------------------------------------------------------
+// RocksDB Storage
+// -----------------------------------------------------------------------------
+pub struct RocksStorage {
+    db: DB,
+}
+
+impl RocksStorage {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        let cfs = vec![
+            ColumnFamilyDescriptor::new("default", Options::default()), // Metadata (ConsensusState)
+            ColumnFamilyDescriptor::new("blocks", Options::default()),
+            ColumnFamilyDescriptor::new("qcs", Options::default()),
+        ];
+
+        let db = DB::open_cf_descriptors(&opts, path, cfs)?;
+        Ok(Self { db })
+    }
+}
+
+impl Storage for RocksStorage {
+    fn save_block(&self, block: &Block) -> Result<(), StorageError> {
+        let hash = crate::crypto::hash_data(block);
+        let cf = self.db.cf_handle("blocks").unwrap();
+        let key = hash.0; // [u8; 32]
+        let val = bincode::serialize(block)?;
+        self.db.put_cf(cf, key, val)?;
+        Ok(())
+    }
+
+    fn get_block(&self, hash: &Hash) -> Result<Option<Block>, StorageError> {
+        let cf = self.db.cf_handle("blocks").unwrap();
+        if let Some(val) = self.db.get_cf(cf, hash.0)? {
+            let block = bincode::deserialize(&val)?;
+            Ok(Some(block))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn save_qc(&self, qc: &QuorumCertificate) -> Result<(), StorageError> {
+        let cf = self.db.cf_handle("qcs").unwrap();
+        let key = qc.view.to_be_bytes();
+        let val = bincode::serialize(qc)?;
+        self.db.put_cf(cf, key, val)?;
+        Ok(())
+    }
+
+    fn get_qc(&self, view: View) -> Result<Option<QuorumCertificate>, StorageError> {
+        let cf = self.db.cf_handle("qcs").unwrap();
+        if let Some(val) = self.db.get_cf(cf, view.to_be_bytes())? {
+            let qc = bincode::deserialize(&val)?;
+            Ok(Some(qc))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn save_consensus_state(&self, state: &ConsensusState) -> Result<(), StorageError> {
+        let key = b"consensus_state";
+        // Default CF
+        let val = bincode::serialize(state)?;
+        self.db.put(key, val)?;
+        Ok(())
+    }
+
+    fn get_consensus_state(&self) -> Result<Option<ConsensusState>, StorageError> {
+        let key = b"consensus_state";
+        if let Some(val) = self.db.get(key)? {
+            let state = bincode::deserialize(&val)?;
+            Ok(Some(state))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/tests/persistence_test.rs
+++ b/tests/persistence_test.rs
@@ -1,0 +1,40 @@
+use ockham::consensus::SimplexState;
+use ockham::crypto::generate_keypair;
+use ockham::storage::RocksStorage;
+use std::fs;
+
+#[test]
+fn test_rocksdb_persistence() {
+    let db_path = "./target/test_db_persistence";
+    let _ = fs::remove_dir_all(db_path);
+
+    let (pk, sk) = generate_keypair();
+    let committee = vec![pk.clone()];
+
+    // 1. First run: Initialize and create Genesis
+    {
+        let storage = Box::new(RocksStorage::new(db_path).unwrap());
+        let state = SimplexState::new(pk.clone(), sk.clone(), committee.clone(), storage);
+
+        assert_eq!(state.current_view, 1);
+        assert_eq!(state.finalized_height, 0);
+        // Genesis should be saved
+    } // state dropped, DB closed
+
+    // 2. Second run: Load from DB
+    {
+        let storage = Box::new(RocksStorage::new(db_path).unwrap());
+        // Use same key/committee (irrelevant for loading state, but needed for struct)
+        let state = SimplexState::new(pk.clone(), sk.clone(), committee.clone(), storage);
+
+        // Should have loaded state
+        assert_eq!(state.current_view, 1);
+        assert_eq!(state.finalized_height, 0);
+
+        // Verify we can retrieve Genesis block
+        let genesis_block = state.storage.get_block(&state.preferred_block).unwrap();
+        assert!(genesis_block.is_some());
+    }
+
+    let _ = fs::remove_dir_all(db_path);
+}

--- a/tests/timeout_test.rs
+++ b/tests/timeout_test.rs
@@ -10,8 +10,14 @@ fn test_timeout_chain_extension() {
     let committee: Vec<PublicKey> = keys.iter().map(|k| k.0.clone()).collect();
 
     // Node 0
-    let mut node0 = SimplexState::new(keys[0].0.clone(), keys[0].1.clone(), committee.clone());
-    let genesis_block_hash = hash_data(node0.blocks.values().next().unwrap());
+    let storage = Box::new(ockham::storage::MemStorage::new());
+    let mut node0 = SimplexState::new(
+        keys[0].0.clone(),
+        keys[0].1.clone(),
+        committee.clone(),
+        storage,
+    );
+    let genesis_block_hash = node0.preferred_block;
 
     // --- VIEW 1 (Normal) ---
     // Create Block 1
@@ -51,7 +57,7 @@ fn test_timeout_chain_extension() {
     node0.on_vote(v2).unwrap();
 
     // Check QC2 is formed (Dummy)
-    let qc2 = node0.qcs.get(&2).expect("QC2 should exist");
+    let qc2 = node0.storage.get_qc(2).unwrap().expect("QC2 should exist");
     assert_eq!(qc2.block_hash, ockham::crypto::Hash::default());
 
     // Check Preferred Block is STILL B1 (Not Dummy)


### PR DESCRIPTION
This PR integrates RocksDB for persistent consensus state storage.

## Changes
- **Dependency**: Added `rocksdb` and `bincode`.
- **Storage Module**: Added `src/storage.rs` with `Storage` trait and `RocksStorage` implementation.
- **Consensus**: Refactored `SimplexState` to use `Box<dyn Storage>` instead of in-memory HashMaps.
- **Main**: Updated `main.rs` to clear previous state and initialize RocksDB at startup.
- **Tests**:
    - Updated existing tests to use `MemStorage`.
    - Added `tests/persistence_test.rs` to verify state survival across restarts.

## Verification
- `cargo test` passes (unit + integration + persistence).