### PR TITLE
feat: implement standard RPC methods (Issue 32)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -37,6 +37,15 @@ impl OckhamClient {
         Ok(balance)
     }
 
+    pub async fn get_transaction_count(
+        &self,
+        address: Address,
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        let params = rpc_params![address];
+        let nonce: u64 = self.client.request("get_transaction_count", params).await?;
+        Ok(nonce)
+    }
+
     pub async fn send_transaction(
         &self,
         nonce: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         committee,
         storage.clone(),
         tx_pool.clone(),
-        executor,
+        executor.clone(),
         block_gas_limit,
     );
 
@@ -82,6 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rpc_impl = OckhamRpcImpl::new(
         storage.clone(),
         tx_pool.clone(),
+        executor.clone(),
         block_gas_limit,
         bg_tx_sender,
     );

--- a/tests/rpc_test.rs
+++ b/tests/rpc_test.rs
@@ -24,10 +24,16 @@ async fn test_rpc_get_status() {
     storage.save_consensus_state(&state).unwrap();
 
     let tx_pool = Arc::new(ockham::tx_pool::TxPool::new(storage.clone()));
+    let state_manager = Arc::new(std::sync::Mutex::new(ockham::state::StateManager::new(
+        storage.clone(),
+        None,
+    )));
+    let executor = ockham::vm::Executor::new(state_manager, ockham::types::DEFAULT_BLOCK_GAS_LIMIT);
     let (tx_sender, _rx) = tokio::sync::mpsc::channel(100);
     let rpc = OckhamRpcImpl::new(
         storage,
         tx_pool,
+        executor,
         ockham::types::DEFAULT_BLOCK_GAS_LIMIT,
         tx_sender,
     );
@@ -82,10 +88,16 @@ async fn test_rpc_get_block() {
     storage.save_consensus_state(&state).unwrap();
 
     let tx_pool = Arc::new(ockham::tx_pool::TxPool::new(storage.clone()));
+    let state_manager = Arc::new(std::sync::Mutex::new(ockham::state::StateManager::new(
+        storage.clone(),
+        None,
+    )));
+    let executor = ockham::vm::Executor::new(state_manager, ockham::types::DEFAULT_BLOCK_GAS_LIMIT);
     let (tx_sender, _rx) = tokio::sync::mpsc::channel(100);
     let rpc = OckhamRpcImpl::new(
         storage,
         tx_pool,
+        executor,
         ockham::types::DEFAULT_BLOCK_GAS_LIMIT,
         tx_sender,
     );
@@ -123,4 +135,121 @@ async fn test_rpc_get_block() {
     // So calculation might return 0? Or if target > 0, decrease?
     // Let's just check it returns Ok for MVP.
     println!("Suggested Base Fee: {:?}", fee);
+}
+
+#[tokio::test]
+async fn test_rpc_get_transaction_count() {
+    let storage = Arc::new(MemStorage::new());
+
+    // Create an account with a specific nonce
+    let (pk, _) = ockham::crypto::generate_keypair();
+    let pk_bytes = pk.0.to_bytes();
+    let hash = ockham::types::keccak256(pk_bytes);
+    let address = ockham::types::Address::from_slice(&hash[12..]);
+
+    let account = ockham::storage::AccountInfo {
+        nonce: 42,
+        balance: ockham::types::U256::ZERO,
+        code_hash: ockham::crypto::Hash(ockham::types::keccak256([]).into()),
+        code: None,
+    };
+    storage.save_account(&address, &account).unwrap();
+
+    let tx_pool = Arc::new(ockham::tx_pool::TxPool::new(storage.clone()));
+    let state_manager = Arc::new(std::sync::Mutex::new(ockham::state::StateManager::new(
+        storage.clone(),
+        None,
+    )));
+    let executor = ockham::vm::Executor::new(state_manager, ockham::types::DEFAULT_BLOCK_GAS_LIMIT);
+    let (tx_sender, _rx) = tokio::sync::mpsc::channel(100);
+    let rpc = OckhamRpcImpl::new(
+        storage,
+        tx_pool,
+        executor,
+        ockham::types::DEFAULT_BLOCK_GAS_LIMIT,
+        tx_sender,
+    );
+
+    // Call RPC
+    let result = rpc.get_transaction_count(address);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 42);
+
+    // Test non-existent account
+    let (pk2, _) = ockham::crypto::generate_keypair();
+    let pk2_bytes = pk2.0.to_bytes();
+    let hash2 = ockham::types::keccak256(pk2_bytes);
+    let address2 = ockham::types::Address::from_slice(&hash2[12..]);
+
+    let result2 = rpc.get_transaction_count(address2);
+    assert!(result2.is_ok());
+    assert_eq!(result2.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_rpc_extended() {
+    let storage = Arc::new(MemStorage::new());
+    // Setup Account with Code
+    let (pk, _) = ockham::crypto::generate_keypair();
+    let pk_bytes = pk.0.to_bytes();
+    let hash = ockham::types::keccak256(pk_bytes);
+    let address = ockham::types::Address::from_slice(&hash[12..]);
+
+    let code_bytes = vec![0x60, 0x00, 0x60, 0x00, 0x53]; // PUSH1 00 PUSH1 00 MSTORE8 (Simple nonsense)
+    let code_hash = ockham::crypto::Hash(ockham::types::keccak256(&code_bytes).into());
+    let code = ockham::types::Bytes::from(code_bytes.clone());
+
+    let account = ockham::storage::AccountInfo {
+        nonce: 1,
+        balance: ockham::types::U256::from(100),
+        code_hash,
+        code: Some(code.clone()),
+    };
+    storage.save_account(&address, &account).unwrap();
+    storage.save_code(&code_hash, &code).unwrap();
+
+    let tx_pool = Arc::new(ockham::tx_pool::TxPool::new(storage.clone()));
+    let state_manager = Arc::new(std::sync::Mutex::new(ockham::state::StateManager::new(
+        storage.clone(),
+        None,
+    )));
+    let executor = ockham::vm::Executor::new(state_manager, ockham::types::DEFAULT_BLOCK_GAS_LIMIT);
+    let (tx_sender, _rx) = tokio::sync::mpsc::channel(100);
+    let rpc = OckhamRpcImpl::new(
+        storage,
+        tx_pool,
+        executor,
+        ockham::types::DEFAULT_BLOCK_GAS_LIMIT,
+        tx_sender,
+    );
+
+    // 1. get_code
+    let res_code = rpc.get_code(address, None);
+    assert!(res_code.is_ok());
+    assert_eq!(res_code.unwrap(), code);
+
+    // 2. call (to the account)
+    let request = ockham::rpc::CallRequest {
+        from: None,
+        to: Some(address),
+        gas: Some(100000),
+        gas_price: None,
+        value: None,
+        data: None,
+    };
+    let res_call = rpc.call(request, None);
+    assert!(res_call.is_ok());
+
+    // 3. estimate_gas
+    let request_est = ockham::rpc::CallRequest {
+        from: None,
+        to: Some(address),
+        gas: None,
+        gas_price: None,
+        value: None,
+        data: None,
+    };
+    let res_est = rpc.estimate_gas(request_est, None);
+    assert!(res_est.is_ok());
+    println!("Estimated Gas: {}", res_est.unwrap());
 }


### PR DESCRIPTION
Implements call, estimate_gas, get_code, get_block_by_number. Verified with tests.

Closes #32 